### PR TITLE
babel: missing *.mo files logging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,19 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-
-# TODO: Generate this manifest file by running the following commands:
-#
-#  git init
-#  git add -A
-#  pip install -e .[all]
-#  check-manifest -u
-
-# Check manifest will not automatically add these two files:
 include .dockerignore
 include .editorconfig
-
-# added by check_manifest.py
 include *.rst
 include *.sh
 include *.txt
@@ -48,6 +37,7 @@ recursive-include docs Makefile
 recursive-include misc *.py
 recursive-include misc *.rst
 recursive-include tests *.py
-
-# added by check_manifest.py
 recursive-include invenio_i18n *.po
+recursive-include invenio_i18n *.mo
+recursive-include tests *.po
+recursive-include tests *.mo

--- a/invenio_i18n/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_i18n/translations/en/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 
 #: invenio_i18n/babel.py:41
 msgid "Translate"
-msgstr ""
+msgstr "Translate"
 
 #: invenio_i18n/babel.py:42
 #, python-format

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,6 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 python setup.py compile_catalog && \
+pybabel compile -d tests/translations/ -l en && \
 pep257 invenio_i18n && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \

--- a/tests/translations/en/LC_MESSAGES/messages.po
+++ b/tests/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio-i18n 0.1.0.dev20150000\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2015-10-09 17:20+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.1.1\n"
+
+msgid "Test string"
+msgstr "Test string from test"
+
+#: invenio_i18n/babel.py:41
+msgid "Translate"
+msgstr "From test catalog"


### PR DESCRIPTION
* Changes missing locale to not raise exception but instead log
  a message.

* Adds method to set locale in request context.

Co-authored-by: Jiri Kuncar <jiri.kuncar@cern.ch>
Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>