### PR TITLE
selectors: fix locale selection with AnonymousUser

### DIFF
--- a/invenio_i18n/selectors.py
+++ b/invenio_i18n/selectors.py
@@ -70,7 +70,7 @@ def get_locale():
     if hasattr(current_app, 'login_manager') and \
             current_user.is_authenticated:
         language_user_key = current_app.config['I18N_USER_LANG_ATTR']
-        if getattr(current_user, language_user_key) in locales:
+        if getattr(current_user, language_user_key, None) in locales:
             return getattr(current_user, language_user_key)
 
     # Using the headers that the navigator has sent.

--- a/tests/test_invenio_i18n_selectors.py
+++ b/tests/test_invenio_i18n_selectors.py
@@ -141,3 +141,15 @@ def test_get_locale_default(app):
 
     with app.test_request_context():
         assert 'en' == get_locale()
+
+
+def test_get_locale_anonymous_user(app):
+    """Test anonymous user locale selection by default."""
+    app.secret_key = 'secret key'
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+    login_manager.login_view = 'login'
+    InvenioI18N(app)
+
+    with app.test_request_context():
+        assert 'en' == get_locale()


### PR DESCRIPTION
* Fixes the selection of locale when the current_user object does not
  have I18N_USER_LANG_ATTR property.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>