### PR TITLE
release: v1.0.0a2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@
 Changes
 =======
 
-Version 1.0.0 (released 2015-11-27)
+Version 1.0.0 (released 2015-12-01)
 -----------------------------------
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -2,7 +2,7 @@
  Invenio-I18N v1.0.0
 =====================
 
-Invenio-I18N v1.0.0 was released on November 27, 2015.
+Invenio-I18N v1.0.0 was released on December 1, 2015.
 
 About
 -----


### PR DESCRIPTION
* Fixes release of v1.0.0a2. Release in commit c498e1f8 failed tests
  when it was merged 3 days after PR successfully passed tests, and
  thus the v1.0.0a2 was never released on PyPI.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>