### PR TITLE
jinja2: current language/local context processors

### DIFF
--- a/invenio_i18n/babel.py
+++ b/invenio_i18n/babel.py
@@ -41,10 +41,11 @@ def set_locale(ln):
     ctx = _request_ctx_stack.top
     if ctx is None:
         raise RuntimeError("Working outside of request context.")
-    locale = getattr(ctx, 'babel_locale', None)
-    setattr(ctx, 'babel_locale', ln)
+    new_locale = current_app.extensions['babel'].load_locale(ln)
+    old_locale = getattr(ctx, 'babel_locale', None)
+    setattr(ctx, 'babel_locale', new_locale)
     yield
-    setattr(ctx, 'babel_locale', locale)
+    setattr(ctx, 'babel_locale', old_locale)
 
 
 class MultidirDomain(Domain):

--- a/invenio_i18n/jinja2.py
+++ b/invenio_i18n/jinja2.py
@@ -30,7 +30,8 @@ https://pythonhosted.org/Flask-BabelEx/
 
 from __future__ import absolute_import, print_function
 
-from flask_babelex import to_user_timezone, to_utc
+from flask import current_app
+from flask_babelex import get_locale, to_user_timezone, to_utc
 
 
 def filter_to_user_timezone(dt):
@@ -47,3 +48,15 @@ def filter_to_utc(dt):
     Installed on application as ``toutc``.
     """
     return to_utc(dt)
+
+
+def filter_language_name(lang_code):
+    """Convert language code into display name in current locale."""
+    return current_app.extensions['babel'].load_locale(
+        lang_code).get_display_name(get_locale().language)
+
+
+def filter_language_name_local(lang_code):
+    """Convert language code into display name in local locale."""
+    return current_app.extensions['babel'].load_locale(
+        lang_code).display_name

--- a/tests/test_babel.py
+++ b/tests/test_babel.py
@@ -30,7 +30,7 @@ from os.path import dirname, join
 
 import pytest
 from babel.support import NullTranslations, Translations
-from flask_babelex import get_locale
+from flask_babelex import Babel, get_locale
 
 from invenio_i18n.babel import MultidirDomain, set_locale
 
@@ -48,6 +48,8 @@ def test_init():
 
 def test_merge_translations(app):
     """Test initialization."""
+    Babel(app)
+
     d = MultidirDomain(
         paths=[join(dirname(__file__), 'translations')],
         entry_point_group='invenio_i18n.translations')
@@ -80,6 +82,7 @@ def test_get_translations():
 def test_get_translations_existing_and_missing_mo(app):
     """Test get translations for language with existing/missing *.mo files."""
     app.config['I18N_LANGUAGES'] = [('de', 'German')]
+    Babel(app)
 
     d = MultidirDomain(entry_point_group='invenio_i18n.translations')
 
@@ -93,6 +96,7 @@ def test_get_translations_existing_and_missing_mo(app):
 def test_set_locale(app):
     """Test get translations for language with existing/missing *.mo files."""
     # Wokring outside request context
+    Babel(app)
     try:
         with set_locale('en'):
             assert False
@@ -101,6 +105,6 @@ def test_set_locale(app):
 
     with app.test_request_context():
         with set_locale('en'):
-            assert get_locale() == 'en'
+            assert str(get_locale()) == 'en'
         with set_locale('da'):
-            assert get_locale() == 'da'
+            assert str(get_locale()) == 'da'


### PR DESCRIPTION
* Adds context processors to allow access to current language and
  locale from templates.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>