### PR TITLE
docs: macros and example application

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,11 +6,3 @@ Invenio-I18N is on PyPI so all you need is:
 .. code-block:: console
 
    $ pip install invenio-i18n
-
-If you want the development version instead, you can install it directly from
-our GitHub repository:
-
-.. code-block:: console
-
-   $ pip install git+https://github.com/inveniosoftware/invenio-i18n.git
-

--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,14 @@
         :target: https://github.com/inveniosoftware/invenio-i18n/blob/master/LICENSE
 
 
-Invenio internationalization module.
+Invenio internationalization module based on
+`Flask-BabelEx <https://pythonhosted.org/Flask-BabelEx/>`_.
 
-*This is an experimental developer preview release.*
+Features:
 
-* Free software: GPLv2 license
-* Documentation: https://invenio-i18n.readthedocs.io/
+* Loading and merging message catalogs.
+* Algorithm for detecting a user's locale.
+* Views for changing the locale.
+* Jinja2 macros and filters for I18N.
+
+Further documentation available at https://invenio-i18n.readthedocs.io/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015, 2016 CERN.
+    Copyright (C) 2017 CERN.
 
     Invenio is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
@@ -21,45 +21,8 @@
     waive the privileges and immunities granted to it by virtue of its status
     as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+Configuration
+=============
 
-.. include:: ../README.rst
-
-User's Guide
-------------
-
-This part of the documentation will show you how to get started in using
-Invenio-I18N.
-
-.. toctree::
-   :maxdepth: 2
-
-   installation
-   configuration
-   usage
-   examplesapp
-
-
-API Reference
--------------
-
-If you are looking for information on a specific function, class or method,
-this part of the documentation is for you.
-
-.. toctree::
-   :maxdepth: 2
-
-   api
-
-Additional Notes
-----------------
-
-Notes on how to contribute, legal information and changes are here for the
-interested.
-
-.. toctree::
-   :maxdepth: 1
-
-   contributing
-   changes
-   license
-   authors
+.. automodule:: invenio_i18n.config
+   :members:

--- a/examples/app.py
+++ b/examples/app.py
@@ -39,6 +39,10 @@ Run example development server:
 
     $ FLASK_APP=app.py flask run --debugger -p 5000
 
+The example application will render "Hello World" and display language
+selectors for english, danish and spanish that allow you to change the text to
+the given language.
+
 To be able to uninstall the example app:
 
 .. code-block:: console
@@ -55,6 +59,7 @@ from invenio_i18n import InvenioI18N
 # Create Flask application
 app = Flask(__name__)
 app.config.update(
+    SECRET_KEY='CHANGE_ME',
     I18N_LANGUAGES=[('da', 'Danish'), ('en', 'English'), ('es', 'Spanish')],
 )
 InvenioI18N(app)

--- a/examples/templates/invenio_i18n/page.html
+++ b/examples/templates/invenio_i18n/page.html
@@ -7,6 +7,7 @@
 <body>
 <p>{{_('Hello world')}}</p>
 
+<h3>Using ln query parameter:</h3>
 <ul>
     <li>
         <a href="?ln=en">English version</a>
@@ -18,5 +19,15 @@
         <a href="?ln=es">Spanish version</a>
     </li>
 </ul>
+
+<h3>Using language selector macros:</h3>
+{% from "invenio_i18n/macros/language_selector.html" import language_selector,
+   language_selector_form, language_selector_dropdown %}
+<pre>language_selector</pre>
+{{ language_selector() }}
+<pre>language_selector_form</pre>
+{{ language_selector_form() }}
+<pre>language_selector_dropdown</pre>
+{{ language_selector_dropdown() }}
 </body>
 </html>

--- a/invenio_i18n/__init__.py
+++ b/invenio_i18n/__init__.py
@@ -62,17 +62,6 @@ True
 ...     gettext('Language:') == 'Jazyk:'
 True
 
-Configuration
--------------
-
-.. automodule:: invenio_i18n.config
-   :members:
-
-In addition, Flask-BabelEx also sets system-wide defaults. For further details
-see:
-
- * https://pythonhosted.org/Flask-BabelEx/#configuration
-
 Marking strings for translation
 -------------------------------
 Following is a short overview on how to mark strings in Python code and
@@ -149,6 +138,28 @@ context:
   (see :func:`~invenio_i18n.jinja2.filter_language_name`).
 * ``language_name_local`` converts language code into display name in local
   locale (see :func:`~invenio_i18n.jinja2.filter_language_name_local`).
+
+Macros
+~~~~~~
+Invenio-I18N also provides three templates macros that you can use to render a
+language selector in templates with:
+
+* ``language_selector`` - Renders a list of links and uses GET requests to
+  change the locale.
+* ``language_selector_form`` - Same as above, but uses POST requests to change
+  the locale.
+* ``language_selector_dropdown`` - Renders a dropdown with languages and uses
+  a POST request to change the locale.
+
+You use the macros by importing one of them from
+``invenio_i18n/macros/language_selector.html``, for instance:
+
+>>> with app.test_request_context():
+...     r = render_template_string(
+...         '{% from "invenio_i18n/macros/language_selector.html"'
+...         '   import language_selector %}'
+...         '{{ language_selector() }}'
+...     )
 """
 
 from __future__ import absolute_import, print_function

--- a/invenio_i18n/config.py
+++ b/invenio_i18n/config.py
@@ -22,7 +22,13 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Configuration for the Invenio internationalization module."""
+"""Configuration for the Invenio internationalization module.
+
+In addition to the configuration variables listed below, Flask-BabelEx also
+sets system-wide defaults. For further details see:
+
+ * https://pythonhosted.org/Flask-BabelEx/#configuration
+"""
 
 I18N_TRANSLATIONS_PATHS = []
 """List of paths to load message catalogs from."""


### PR DESCRIPTION
* Adds usage documentation of template macros.

* Improves example application and documentation to include language
  selectors as well.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>