### PR TITLE
templates: language selector dropdown fix

### DIFF
--- a/examples/templates/invenio_i18n/page.html
+++ b/examples/templates/invenio_i18n/page.html
@@ -7,6 +7,7 @@
 <body>
 <p>{{_('Hello world')}}</p>
 
+<h3>Using ln query parameter (overrides session):</h3>
 <ul>
     <li>
         <a href="?ln=en">English version</a>

--- a/invenio_i18n/ext.py
+++ b/invenio_i18n/ext.py
@@ -140,7 +140,7 @@ class InvenioI18N(object):
         app.add_template_filter(filter_language_name, name='language_name')
         app.add_template_filter(
             filter_language_name_local, name='language_name_local')
-        app.context_processor(lambda: dict(current_i18n=current_i18n))
+        app.add_template_global(current_i18n, name='current_i18n')
 
         # Lazy string aware JSON encoder.
         app.json_encoder = get_lazystring_encoder(app)

--- a/invenio_i18n/templates/invenio_i18n/macros/language_selector.html
+++ b/invenio_i18n/templates/invenio_i18n/macros/language_selector.html
@@ -45,7 +45,7 @@
       <p class="form-control-static">{{ _('Language:') }}</p>
       <select name="lang_code" onchange="this.form.submit()">
         {% for language_item in config.I18N_LANGUAGES %}
-          <option value="{{ language_item[0] }}">{{ language_item[1] }}</option>
+          <option {% if current_i18n.language == language_item[0] %}selected {% endif %}value="{{ language_item[0] }}">{{ language_item[1] }}</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
* FIX Fixes issue with language selector dropdown not allowing
  to choose first language in dropdown. (closes #40)

* FIX Changes current_i18n into a template global to make it
  available in e.g. macros.

Signed-off-by: Paulina Lach <paulina.malgorzata.lach@cern.ch>