### PR TITLE
macros: language selector fixes

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -54,13 +54,15 @@ from __future__ import absolute_import, print_function
 
 from flask import Flask, render_template
 
+from flask_babelex import lazy_gettext as _
 from invenio_i18n import InvenioI18N
 
 # Create Flask application
 app = Flask(__name__)
 app.config.update(
     SECRET_KEY='CHANGE_ME',
-    I18N_LANGUAGES=[('da', 'Danish'), ('en', 'English'), ('es', 'Spanish')],
+    BABEL_DEFAULT_LOCALE='en',
+    I18N_LANGUAGES=[('da', _('Danish')), ('es', _('Spanish'))],
 )
 InvenioI18N(app)
 

--- a/examples/templates/invenio_i18n/page.html
+++ b/examples/templates/invenio_i18n/page.html
@@ -7,27 +7,36 @@
 <body>
 <p>{{_('Hello world')}}</p>
 
-<h3>Using ln query parameter (overrides session):</h3>
+<h3>Using ln query parameter (overrides everything else):</h3>
 <ul>
+    {% for l in current_i18n.get_locales() %}
     <li>
-        <a href="?ln=en">English version</a>
+        <a href="?ln={{l.language}}">{{l.get_display_name()}}</a>
     </li>
-    <li>
-        <a href="?ln=da">Danish version</a>
-    </li>
-    <li>
-        <a href="?ln=es">Spanish version</a>
-    </li>
+    {% endfor %}
 </ul>
 
 <h3>Using language selector macros:</h3>
 {% from "invenio_i18n/macros/language_selector.html" import language_selector,
    language_selector_form, language_selector_dropdown %}
+<hr />
 <pre>language_selector</pre>
 {{ language_selector() }}
+<hr />
 <pre>language_selector_form</pre>
 {{ language_selector_form() }}
+<hr />
 <pre>language_selector_dropdown</pre>
 {{ language_selector_dropdown() }}
+
+<h3>Debug:</h3>
+<table>
+<tr><td>Selected language:</td><td><pre>{{ current_i18n.locale.language }}</pre></td></tr>
+<tr><td>1. Language from request query string (?ln=):</td><td><pre>{{ 'ln' in request.args }}</pre></td></tr>
+<tr><td>2. Language from session (key '{{config.I18N_SESSION_KEY}}'):</td><td><pre>{{ session.get(config.I18N_SESSION_KEY) }}</pre></td></tr>
+<tr><td>3. Language from current_user:</td><td><pre>{{ getattr(current_user, config.I18N_USER_LANG_ATTR, None) if current_user else None }}</pre></td></tr>
+<tr><td>4. Language from Accept-Language header:</td><td><pre>{{request.headers.get('Accept-Language')}}</pre></td></tr>
+<tr><td>5. Language from default locale:</td><td><pre>{{ config.BABEL_DEFAULT_LOCALE }}</pre></td></tr>
+</table>
 </body>
 </html>

--- a/invenio_i18n/config.py
+++ b/invenio_i18n/config.py
@@ -36,6 +36,14 @@ I18N_TRANSLATIONS_PATHS = []
 I18N_LANGUAGES = []
 """List of tuples of available languages.
 
+Example configuration with english and danish with english as default language:
+
+.. code-block:: python
+
+    from flask_babelex import lazy_gettext as _
+    BABEL_DEFAULT_LOCALE = 'en'
+    I18N_LANGUAGES = (('da', _('Danish')),)
+
 .. note:: You should not include ``BABEL_DEFAULT_LOCALE`` in this list.
 """
 

--- a/invenio_i18n/templates/invenio_i18n/macros/language_selector.html
+++ b/invenio_i18n/templates/invenio_i18n/macros/language_selector.html
@@ -29,9 +29,8 @@
         method="POST">
     <div class="form-group">
       <p class="form-control-static">{{ _('Language:') }}</p>
-      {% for language_item in config.I18N_LANGUAGES %}
-        <button class="btn btn-link" name="lang_code" type="submit"
-                value="{{ language_item[0] }}">{{ language_item[1] }}</button>
+      {% for l in current_i18n.get_locales() %}
+        <button class="btn btn-link" name="lang_code" type="submit" value="{{ l.language }}" {% if current_i18n.language == lang %}disabled{% endif%}>{{ l.get_display_name() }}</button>
       {% endfor %}
     </div>
   </form>
@@ -44,8 +43,8 @@
     <div class="form-group">
       <p class="form-control-static">{{ _('Language:') }}</p>
       <select name="lang_code" onchange="this.form.submit()">
-        {% for language_item in config.I18N_LANGUAGES %}
-          <option {% if current_i18n.language == language_item[0] %}selected {% endif %}value="{{ language_item[0] }}">{{ language_item[1] }}</option>
+        {% for l in current_i18n.get_locales() %}
+          <option {% if current_i18n.language == l.language %}selected {% endif %}value="{{ l.language }}">{{ l.get_display_name() }}</option>
         {% endfor %}
       </select>
     </div>
@@ -54,7 +53,11 @@
 
 {% macro language_selector() %}
   <span>{{ _('Language:') }}</span>
-  {% for language_item in config.I18N_LANGUAGES %}
-    <a href="{{ url_for('invenio_i18n.set_lang', lang_code=language_item[0]) }}">{{ language_item[1] }}</a>
-  {% endfor %}
+  {%- for l in current_i18n.get_locales() %}
+    {%- if current_i18n.language != l.language %}
+    <a href="{{ url_for('invenio_i18n.set_lang', lang_code=l.language) }}">{{ l.get_display_name() }}</a>
+    {% else %}
+    <strong>{{ l.get_display_name() }}</strong>
+    {%- endif %}
+  {%- endfor %}
 {% endmacro %}

--- a/invenio_i18n/translations/da/LC_MESSAGES/messages.po
+++ b/invenio_i18n/translations/da/LC_MESSAGES/messages.po
@@ -11,6 +11,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-08-25 11:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>, 2017\n"
 "Language-Team: Danish (https://www.transifex.com/inveniosoftware/teams/23537/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -22,4 +23,4 @@ msgstr ""
 #: invenio_i18n/templates/invenio_i18n/macros/language_selector.html:31
 #: invenio_i18n/templates/invenio_i18n/macros/language_selector.html:41
 msgid "Language:"
-msgstr ""
+msgstr "Sprog:"

--- a/invenio_i18n/translations/sk/LC_MESSAGES/messages.po
+++ b/invenio_i18n/translations/sk/LC_MESSAGES/messages.po
@@ -11,6 +11,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-08-25 11:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: helix84 <helix84@centrum.sk>, 2016\n"
 "Language-Team: Slovak (https://www.transifex.com/inveniosoftware/teams/23537/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -22,4 +23,4 @@ msgstr ""
 #: invenio_i18n/templates/invenio_i18n/macros/language_selector.html:31
 #: invenio_i18n/templates/invenio_i18n/macros/language_selector.html:41
 msgid "Language:"
-msgstr ""
+msgstr "Jazyk:"


### PR DESCRIPTION
* Fixes language selectors which where wrongly using I18N_LANGUAGES
  configuration variable instead of current_i18n.get_locales() to
  iterate over languages.

* Fixes language selectors to display the language title in the locale
  language.

* Adds clarification to documentation on how to properly configure
  languages for Invenio-I18N.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>