### PR TITLE
docs: reference to Flask-BabelEx

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,3 +51,14 @@ Views
 -----
 .. automodule:: invenio_i18n.views
    :members:
+
+Date/time formatting
+--------------------
+For formatting date and time using the current locale settings, you may use the methods provided by `Flask-BabelEx <http://pythonhosted.org/Flask-BabelEx/#formatting-dates>`_.
+
+These methods are also available as Jinja filters:
+
+* `format_datetime <http://pythonhosted.org/Flask-BabelEx/#flask.ext.babelex.format_datetime>`_ as ``datetimeformat``
+* `format_date <http://pythonhosted.org/Flask-BabelEx/#flask.ext.babelex.format_date>`_ as ``dateformat``
+* `format_time <http://pythonhosted.org/Flask-BabelEx/#flask.ext.babelex.format_time>`_ as ``timeformat``
+* `format_timedelta <http://pythonhosted.org/Flask-BabelEx/#flask.ext.babelex.format_timedelta>`_ as ``timedeltaformat``.

--- a/invenio_i18n/ext.py
+++ b/invenio_i18n/ext.py
@@ -46,7 +46,7 @@ current_i18n = LocalProxy(lambda: current_app.extensions['invenio-i18n'])
 
 
 def get_lazystring_encoder(app):
-    """Custom JSONEncoder that handles lazy strings from Babel.
+    """Return a JSONEncoder for handling lazy strings from Babel.
 
     Installed on Flask application by default by :class:`InvenioI18N`.
     """


### PR DESCRIPTION
* References Flask-BabelEx for formatting date and time. (closes #55)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>