### PR TITLE
Fix jquery import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.1.1 (released 2018-12-12)
+
+ - Fix an incorrect JS import.
+
 Version 1.1.0 (released 2018-11-06)
 
  - Introduce webpack support.

--- a/invenio_i18n/assets/js/invenio_i18n/app.js
+++ b/invenio_i18n/assets/js/invenio_i18n/app.js
@@ -9,7 +9,7 @@
 
 import angular from "angular";
 import "angular-gettext/dist/angular-gettext";
-import jquery from "jquery/dist/jquery";
+import * as $ from "jquery/dist/jquery";
 
 angular.module("langSelector", ["gettext"]).factory("setLanguage", [
   "gettextCatalog",

--- a/invenio_i18n/version.py
+++ b/invenio_i18n/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
In my tests integrating ILS with webpack, webpack build was failing because of this wrong import.