### PR TITLE
ci: adapt frontend input variable and path

### DIFF
--- a/.github/workflows/i18n-push-base.yml
+++ b/.github/workflows/i18n-push-base.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: boolean
         default: true
-      frontend-package-name:
+      frontend-package-path:
         required: false
         type: string
     secrets:
@@ -49,15 +49,15 @@ jobs:
 
       # setup node
       - name: Setup node
-        if: ${{ inputs.frontend-package-name != '' }}
+        if: ${{ inputs.frontend-package-path != '' }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE-VERSION }}
 
       # extract frontend messages
       - name: Extract frontend messages
-        if: ${{ inputs.frontend-package-name != '' }}
-        working-directory: ./${{ inputs.frontend-package-name }}/theme/assets/semantic-ui/translations/${{ inputs.frontend-package-name }}
+        if: ${{ inputs.frontend-package-path != '' }}
+        working-directory: ./${{ inputs.frontend-package-path }}
         # installing from package-lock.json
         run: |
           npm ci

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -314,7 +314,11 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
+    # TODO: Configure external documentation references, eg:
+    # 'Flask-Admin': ('https://flask-admin.readthedocs.io/en/latest/', None),
+}
 
 # Autodoc configuraton.
 autoclass_content = "both"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Adapt frontend path so packages can specify completely.
In `invenio-app-rdm`, the path is `invenio_app_rdm/theme/assets/semantic_ui/translations/invenio_app_rdm`, while for most other packages, it is `<package_name>/assets/semantic_ui/translations/<package_name` (i.e. without theme). 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
