### PR TITLE
translation bundle

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details
@@ -15,28 +16,5 @@ on:
 
 jobs:
   Publish:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel babel
-
-      - name: Build package
-        run: python setup.py compile_catalog sdist bdist_wheel
-
-      - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          # The token is provided by the inveniosoftware organization
-          password: ${{ secrets.pypi_token }}
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2022-2023 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -26,43 +26,4 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-          python-version: [3.7, 3.8, 3.9]
-          requirements-level: [pypi]
-
-    env:
-      EXTRAS: tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          pip install wheel requirements-builder
-          requirements-builder -e "$EXTRAS" ${{ matrix.requirements-file }} --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{matrix.requirements-level}}-${{ matrix.python-version }}-requirements.txt
-          pip install -e .[$EXTRAS]
-          pip freeze
-
-      - name: Run translations test
-        run: ./run-i18n-tests.sh
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master

--- a/invenio_i18n/babel.py
+++ b/invenio_i18n/babel.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_i18n/ext.py
+++ b/invenio_i18n/ext.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -58,6 +58,7 @@ class InvenioI18N(object):
         localeselector=None,
         timezoneselector=None,
         entry_point_group="invenio_i18n.translations",
+        translation_bundle_entry_point="invenio_i18n.translations_bundle",
     ):
         """Initialize extension.
 
@@ -77,6 +78,7 @@ class InvenioI18N(object):
             default_domain=self.domain,
         )
         self.entry_point_group = entry_point_group
+        self.translation_bundle_entry_point = translation_bundle_entry_point
         self._locales_cache = None
         self._languages_cache = None
 
@@ -144,6 +146,10 @@ class InvenioI18N(object):
         # 3. Entrypoints
         if self.entry_point_group:
             self.domain.add_entrypoint(self.entry_point_group)
+
+        # 4. bundle entrypoint
+        if self.translation_bundle_entry_point:
+            self.domain.add_entrypoint(self.translation_bundle_entry_point)
 
     def iter_languages(self):
         """Iterate over list of languages."""

--- a/invenio_i18n/ext.py
+++ b/invenio_i18n/ext.py
@@ -138,18 +138,18 @@ class InvenioI18N(object):
         for p in app.config.get("I18N_TRANSLATIONS_PATHS", []):
             self.domain.add_path(p)
 
-        # 2. <app.root_path>/translations
-        app_translations = os.path.join(app.root_path, "translations")
-        if os.path.exists(app_translations):
-            self.domain.add_path(app_translations)
-
-        # 3. Entrypoints
+        # 2. Entrypoints
         if self.entry_point_group:
             self.domain.add_entrypoint(self.entry_point_group)
 
-        # 4. bundle entrypoint
+        # 3. bundle entrypoint
         if self.translation_bundle_entry_point:
             self.domain.add_entrypoint(self.translation_bundle_entry_point)
+
+        # 4. <app.root_path>/translations
+        app_translations = os.path.join(app.root_path, "translations")
+        if os.path.exists(app_translations):
+            self.domain.add_path(app_translations)
 
     def iter_languages(self):
         """Iterate over list of languages."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2022 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,6 +30,7 @@ install_requires =
     Babel>=2.8
     Flask-Babel>=3.0.0
     invenio-base>=1.2.11
+    pytz<2024.2
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
- ext: add bundle entrypoint

a package would look like
├── invenio_translations_de_DE
│   ├── __init__.py
│   └── translations
│       ├── de_DE
│       │   └── LC_MESSAGES
│       │       ├── de_DE.mo
│       │       ├── de_DE.po
│       │       ├── messages.mo
│       │       └── messages.po
│       └── messages.pot
├── setup.cfg
└── setup.py
and the setup.cfg would have:

```
[options.entry_points]
invenio_i18n.translations_bundle =
    messages = invenio_translations_de_DE

[compile_catalog]
directory = invenio_translations_de_DE/translations/
use-fuzzy = True

[extract_messages]
copyright_holder = CERN
msgid_bugs_address = info@inveniosoftware.org
mapping-file = babel.ini
output-file = invenio_translations_de_DE/translations/messages.pot
add-comments = NOTE

[init_catalog]
input-file = invenio_translations_de_DE/translations/messages.pot
output-dir = invenio_translations_de_DE/translations/

[update_catalog]
input-file = invenio_translations_de_DE/translations/messages.pot
output-dir = invenio_translations_de_DE/translations/
```
- reorder

the reorder is because of the way babel combines the translation msgid's

https://github.com/python-babel/babel/blob/master/babel/support.py#L695
