### PR TITLE
fix: setuptools changed something

### DIFF
--- a/.github/workflows/i18n-push-base.yml
+++ b/.github/workflows/i18n-push-base.yml
@@ -24,7 +24,7 @@ jobs:
   i18n-extract:
     runs-on: ubuntu-20.04
     env:
-      PYTHON-VERSION: 3.12
+      PYTHON-VERSION: 3.9
       NODE-VERSION: 18
     steps:
       - name: Checkout


### PR DESCRIPTION
* setuptools changed the way it look at -, so we have to change mapping-file to mapping_file, because - is not a synonym anymore to _. quick fix is to go back to python3.9 because the error doesn't occur there.
