### PR TITLE
fix: DeprecationWarning

### DIFF
--- a/invenio_i18n/babel.py
+++ b/invenio_i18n/babel.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C) 2023-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,8 +10,8 @@
 """Flask-Babel domain for merging translations from many directories."""
 
 import os
-
-from pkg_resources import iter_entry_points, resource_filename, resource_isdir
+from importlib.metadata import entry_points
+from pathlib import Path
 
 
 class MultidirDomain:
@@ -42,11 +42,11 @@ class MultidirDomain:
 
     def add_entrypoint(self, entry_point_group):
         """Load translations from an entry point."""
-        for ep in iter_entry_points(group=entry_point_group):
-            if not resource_isdir(ep.module_name, "translations"):
-                continue
-            dirname = resource_filename(ep.module_name, "translations")
-            self.add_path(dirname)
+        for ep in entry_points(group=entry_point_group):
+            dirname = Path(ep.module) / "translations"
+
+            if dirname.is_dir():
+                self.add_path(str(dirname))
 
     def add_path(self, path):
         """Load translations from an existing path."""


### PR DESCRIPTION
* pkg_resources is deprecated as an API

should fix https://github.com/inveniosoftware/invenio-i18n/issues/148


NOTE: since `group` has been added in python3.10 i would wait to merge this until we drop support for python3.9. 