### PR TITLE
i18n: add invenio_vocabularies to example config in docstring

### DIFF
--- a/invenio_i18n/cli.py
+++ b/invenio_i18n/cli.py
@@ -264,7 +264,8 @@ def fetch_from_transifex(token, languages, output_directory):
             "invenio-communities-messages-ui": "invenio_communities",
             "invenio-rdm-records-messages-ui": "invenio_rdm_records",
             "invenio-requests-messages-ui": "invenio_requests",
-            "invenio-search-ui-messages-js": "invenio_search_ui"
+            "invenio-search-ui-messages-js": "invenio_search_ui",
+            "invenio-vocabularies-messages-ui": "invenio_vocabularies",
         }
 
     Fetching and unifying of translations


### PR DESCRIPTION
### Description

Invenio-vocabularies now also has some JS translations, therefore I added it to the example config for resources to fetch from Transifex.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant documentation.
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
