### PR TITLE
fix(i18n): support pyproject packages

### DIFF
--- a/.github/workflows/i18n-push-base.yml
+++ b/.github/workflows/i18n-push-base.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023-2025 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-i18n is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -13,6 +14,9 @@ on:
         required: true
         type: boolean
         default: true
+      backend-package-path:
+        required: false
+        type: string
       frontend-package-path:
         required: false
         type: string
@@ -45,9 +49,15 @@ jobs:
 
       # extract backend messages
       - name: Extract backend messages
-        if: ${{ inputs.extract-backend }}
+        if: ${{ inputs.extract-backend && inputs.backend-package-path == '' }}
         run: |
           python setup.py extract_messages
+
+      # case for packages using pyproject.toml instead of setup.py
+      - name: Extract backend messages from package path
+        if: ${{ inputs.extract-backend && inputs.backend-package-path != '' }}
+        run: |
+          pybabel extract -F pyproject.toml -o ${{ inputs.backend-package-path }}/translations/messages.pot ${{ inputs.backend-package-path }}
 
       # setup node
       - name: Setup node


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* related to https://github.com/inveniosoftware/invenio-app-rdm/issues/3499
* Add backend package path support for projects without a setup.py file.
* Keep setup.py extraction as the default path while using pybabel for pyproject-based packages.

For packages that no longer provide `setup.py`, pass
`backend-package-path` to the reusable i18n push workflow so backend
messages are extracted with `pybabel` from the package `pyproject.toml`.

```yaml
jobs:
  i18n-extract:
    uses: inveniosoftware/invenio-i18n/.github/workflows/i18n-push-base.yml
    with:
      extract-backend: true
      backend-package-path: invenio_collections
      frontend-package-path: invenio_collections/assets/semantic-ui/translations/invenio_collections
    secrets: inherit
```

* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
