### PR TITLE
fix(ci): bump node, python, action versions

### DIFF
--- a/.github/workflows/i18n-pull-base.yml
+++ b/.github/workflows/i18n-pull-base.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023-2025 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-i18n is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -14,10 +15,10 @@ on:
 
 jobs:
   i18n-pull:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Pull all available translations from transifex
       - name: Pull translated files using transifex client
@@ -27,7 +28,7 @@ jobs:
           args: pull -a -f
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "i18n: pulled translations"
           title: "i18n: pulled translations"

--- a/.github/workflows/i18n-push-base.yml
+++ b/.github/workflows/i18n-push-base.yml
@@ -28,15 +28,15 @@ jobs:
   i18n-extract:
     runs-on: ubuntu-24.04
     env:
-      PYTHON-VERSION: 3.12
-      NODE-VERSION: 22
+      PYTHON-VERSION: 3.14
+      NODE-VERSION: 24
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # setup python
       - name: Set up Python ${{ env.PYTHON-VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON-VERSION }}
 
@@ -62,7 +62,7 @@ jobs:
       # setup node
       - name: Setup node
         if: ${{ inputs.frontend-package-path != '' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE-VERSION }}
 
@@ -83,7 +83,7 @@ jobs:
           args: push -s
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "i18n: push translations"
           title: "i18n: push translations"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* address push warnings about node 20 see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
warning msg:
```

i18n-extract / i18n-extractNode.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5, peter-evans/create-pull-request@v6. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

* changed node version to 24 and python version to 3.14
* Updated actions/checkout and actions/setup-node versions


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
